### PR TITLE
Only rewrite user config on every pman run call

### DIFF
--- a/pman/config.py
+++ b/pman/config.py
@@ -133,6 +133,9 @@ class ConfigDict:
         with open(project_conf_name, 'w') as project_conf_file:
             toml.dump(self.layers['project'], project_conf_file)
 
+        self.write_user()
+
+    def write_user(self):
         user_conf_name = os.path.join(self['internal']['projectdir'], self.USER_CONFIG_NAME)
         with open(user_conf_name, 'w') as user_conf_file:
             toml.dump(self.layers['user'], user_conf_file)

--- a/pman/core.py
+++ b/pman/core.py
@@ -38,7 +38,7 @@ def get_config(startdir=None):
             retcode = subprocess.call(venv_check_args, stderr=subprocess.DEVNULL)
             user_layer['python']['in_venv'] = retcode == 0
 
-            config.write()
+            config.write_user()
         except CouldNotFindPythonError:
             pass
 


### PR DESCRIPTION
This isn't a complete fix for #29 but does fix the annoyance of having my .pman file be unnecessarily rewritten on every `pman run` call.