### PR TITLE
Allow for local, per-project plugins

### DIFF
--- a/pman/plugins/__init__.py
+++ b/pman/plugins/__init__.py
@@ -5,7 +5,7 @@ import functools
 @functools.lru_cache(maxsize=None)
 def _get_all_plugins():
     import pkg_resources
-    
+
     def load_plugin(entrypoint):
         try:
             plugin_class = entrypoint.load()

--- a/pman/plugins/__init__.py
+++ b/pman/plugins/__init__.py
@@ -7,19 +7,46 @@ def _get_all_plugins():
     import pkg_resources
 
     def load_plugin(entrypoint):
-        plugin_class = entrypoint.load()
+        try:
+            plugin_class = entrypoint.load()
+        except ModuleNotFoundError:
+            return None
         if not hasattr(plugin_class, 'name'):
             plugin_class.name = entrypoint.name
         return plugin_class()
 
-    return [
+    return [plugin for plugin in [
         load_plugin(entrypoint)
         for entrypoint in pkg_resources.iter_entry_points('pman.plugins')
-    ]
+    ] if plugin is not None]
+
+
+def _get_project_plugins():
+    import glob
+    import importlib
+    import os
+    import sys
+    
+    plugins = []
+    sys.path = [os.getcwd()] + sys.path
+    
+    plugins_path = os.path.join(os.getcwd(), "plugins")
+    for python_file in glob.glob(plugins_path + "/*.py"):
+        plugin_name = os.path.splitext(os.path.basename(python_file))[0]
+        if plugin_name == "__init__":
+            continue
+        module = importlib.import_module("plugins." + plugin_name)
+        for attrib in dir(module):
+            if attrib.endswith("Plugin"):
+                project_plugin = getattr(module, attrib)()
+                project_plugin.name = plugin_name
+                plugins.append(project_plugin)
+                
+    return plugins
 
 
 def get_plugins(*, filter_names=None, has_attr=None):
-    plugins = _get_all_plugins()
+    plugins = _get_all_plugins() + _get_project_plugins()
 
     def use_plugin(plugin):
         return (


### PR DESCRIPTION
**Edit: I am currently reworking this as I have realized this relies on a dist-info present in the working directory, which is not the wanted behaviour at all !**

This small change allow to have custom converters in a given project.
It is more like a proof of concept and should probably be reworked/cleaned up.
Project plugins should be located in a "plugins" directory.

Current limitations:
* the plugin class name must be the same name as the file, but starting with a capital letter ;
* plugins can only be located in the plugins subdirectory, and nested subdirs are not yet possible ;

Some use-cases:
* Have a tool to create NPC (both mesh and in-game properties, or even scripts) and export them automatically ;
* Mesh generation based on parametric files ;
* Conversion of table-based data (for instance an ODS table listing all the items or monsters) to a more game-friendly format (XML, json, SQLite...)
* ...